### PR TITLE
爆風の挙動を修正。プレイヤーとの当たり判定を作成

### DIFF
--- a/Bomb/Bomb.cpp
+++ b/Bomb/Bomb.cpp
@@ -1,10 +1,11 @@
 #include "Bomb.h"
 #include "../DX12operator.h"
 #include "../Shader/ShaderManager.h"
-
+#include "../Player/Player.h"
 namespace
 {
 	const int explosionTimerMax = 30;
+	const int safeTimerMax = 10;
 }
 Bomb::Bomb()
 {
@@ -74,7 +75,7 @@ void Bomb::EnemyBombCollision(EnemyBase &enemyData)
 	//”š’e‚ÆÚG‚µ‚Ä‚¢‚½‚ç”š”­‚·‚é
 	if (IsBlast)
 	{
-	//”š’e–{‘Ì‚ÆÚG‚µ‚Ä‚¢‚é‚©‚Ì”»’è
+		//”š’e–{‘Ì‚ÆÚG‚µ‚Ä‚¢‚é‚©‚Ì”»’è
 		BombCollision(enemyPosition, 0);
 		Explosion();
 	}
@@ -93,6 +94,25 @@ void Bomb::EnemyBombCollision(EnemyBase &enemyData)
 		enemyData.SetIsWind(IsBlastHit);
 		enemyData.SetWindDirection(blastPower);
 	}
+}
+
+float Bomb::PlayerBlastCollision(XMFLOAT3 pos, float radius)
+{
+	XMVECTOR force;
+	XMFLOAT3 tmpForce;
+	bool isPlayerHit = false;
+	isPlayerHit = BlastCollision(ConvertXMFLOAT3toXMVECTOR(pos), radius, &tmpForce);
+
+	if (isPlayerHit)
+	{
+	force = ConvertXMFLOAT3toXMVECTOR(tmpForce);
+
+		float power =XMVector3Length(force).m128_f32[0];
+		//ƒVƒ“ƒOƒ‹ƒgƒ“‚È‚Ì‚ðˆ«—p‚µ‚Ä‚¢‚Ü‚·
+		Player::GetPlayer()->HitBomb(power);
+		return power;
+	}
+	return 0.0f;
 }
 
 
@@ -180,4 +200,5 @@ void Bomb::Explosion()
 	data.blastTimer = 0;
 	data.isAlive = false;
 	data.isExplosion = true;
+	blastObject.each.scale = XMFLOAT3{ 1.0f, 1.0f, 1.0f };
 }

--- a/Bomb/Bomb.h
+++ b/Bomb/Bomb.h
@@ -13,6 +13,7 @@ struct BombData
 	int blastTimer = 0;//爆発タイマー(とりあえず使わない)
 	bool isAlive = false;//爆弾が現在生きているかどうか
 	bool isExplosion = false;//爆風が発生しているかどうか
+	int safeTimer = 0;//爆弾がプレイヤー接触しても爆発しない時間
 };
 class Bomb
 {
@@ -41,6 +42,8 @@ public:
 	/// </summary>
 	/// <param name="enemyData"></param>
 	void EnemyBombCollision(EnemyBase &enemyData);
+
+	float PlayerBlastCollision(XMFLOAT3 pos, float radius);
 public://アクセッサ
 	bool GetIsAlve() {return data.isAlive;}
 	bool GetIsExplosion(){return data.isExplosion;}


### PR DESCRIPTION
爆風の挙動を再度行った際に場所と大きさが変化しないバグを修正

プレイヤーとの当たり判定の関数を作成
プレイヤーがシングルトンなのを悪用して関数内で呼び出す形をとっているが、
普通にリターンで返すことも可能